### PR TITLE
Adding form decorators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Twitter/Bootstrap/Form/Vertical.php
+++ b/Twitter/Bootstrap/Form/Vertical.php
@@ -18,26 +18,25 @@
  */
 abstract class Twitter_Bootstrap_Form_Vertical extends Twitter_Bootstrap_Form
 {
-    /**
-     * Class constructor override.
-     *
-     * @param null $options
-     */
-    public function __construct($options = null)
-    {
-        parent::__construct($options);
+	/**
+	 * Initialize form
+	 *
+	 * @return void
+	 */
+	public function init()
+	{
+		$this->setElementDecorators(array(
+		    array('FieldSize'),
+		    array('ViewHelper'),
+		    array('ElementErrors'),
+		    array('Description', array('tag' => 'p', 'class' => 'help-block')),
+		    array('Addon')
+		));
 
-        $this->setElementDecorators(array(
-            array('FieldSize'),
-            array('ViewHelper'),
-            array('ElementErrors'),
-            array('Description', array('tag' => 'p', 'class' => 'help-block')),
-            array('Addon')
-        ));
-
-        $this->setDecorators(array(
-            'FormElements',
-            'Form'
-        ));
-    }
+		$this->setDisableLoadDefaultDecorators(true);
+		$this->setDecorators(array(
+		    'FormElements',
+		    'Form'
+		));
+	}
 }


### PR DESCRIPTION
Hi,

I modified Twitter_Bootstrap_Form_Vertical to do it's magic in init() not __construct() so that additional form decorators can be added by specific forms. For example the 'ViewScript' decorator.

``` php
class My_Form extends Twitter_Bootstrap_Form_Horizontal
{
    public function init()
    {
        $this->addDecorator(
            'ViewScript',
            array('viewScript' => 'forms/myviewscript.phtml')
        );
    }
}
```

$this->init() is called by Zend_Form::__construct() so everything is fine.

I recognized to late that you used spaces instead of tabs for indenting - my commit included tabs. If this is a problem, please just revert it back to whitespaces or I can do another pull request.

Furthermore I added a .gitignore with '.DS_Store' ... forgot to create a branch before commiting the above changes :-(
