### PR TITLE
Decorator order for horizontal forms

### DIFF
--- a/Twitter/Bootstrap/Form/Horizontal.php
+++ b/Twitter/Bootstrap/Form/Horizontal.php
@@ -27,9 +27,9 @@ abstract class Twitter_Bootstrap_Form_Horizontal extends Twitter_Bootstrap_Form_
         $this->setElementDecorators(array(
             array('FieldSize'),
             array('ViewHelper'),
+            array('Addon'),
             array('ElementErrors'),
             array('Description', array('tag' => 'p', 'class' => 'help-block')),
-            array('Addon'),
             array('HtmlTag', array('tag' => 'div', 'class' => 'controls')),
             array('Label', array('class' => 'control-label')),
             array('Wrapper')


### PR DESCRIPTION
Hi,

I moved the `Addon` decorator before `ElementErrors` and `Description` - otherwise error messages for fields with an addon destroy the look and feel.

This solution isn't perfect though. The `<span class="help-inline">...</span>` should be rendered within the `<div class="input-append">...</div>` to make it really look good. Haven't had the time to think about how to achieve this.
