### PR TITLE
View_Helper_FormRadio - additional css classes are removed

### DIFF
--- a/Twitter/Bootstrap/View/Helper/FormRadio.php
+++ b/Twitter/Bootstrap/View/Helper/FormRadio.php
@@ -77,7 +77,7 @@ class Twitter_Bootstrap_View_Helper_FormRadio extends Zend_View_Helper_FormEleme
             $label_attribs['class'] = '';
         }
 
-        $label_attribs['class'] = (strlen($label_attribs['class']) > 0 ? ' ' : '') . 'radio';
+        $label_attribs['class'] .= ' radio';
 
         $labelPlacement = 'append';
         foreach ($label_attribs as $key => $val) {


### PR DESCRIPTION
When you need inline radios in your form you must set 'inline' class to input labels.

``` php
$this->addElement('radio', 'accountType', array(
    'label' => 'Inline radio buttons',
    'multiOptions' => array(
        1 => 'One',
        2 => 'Two',
        3 => 'Three',
    ),
    'separator' => '',
    'attribs' => array(
        'label_class' => 'inline',
    )
));
```

Before fix: http://img440.imageshack.us/img440/3397/bootstrapforminlineradi.png

After fix: http://img21.imageshack.us/img21/3397/bootstrapforminlineradi.png
