### PR TITLE
Horizontal / inline / vertical forms should not be abstract

### DIFF
--- a/Twitter/Bootstrap/Form/Horizontal.php
+++ b/Twitter/Bootstrap/Form/Horizontal.php
@@ -16,7 +16,7 @@
  * @subpackage Form
  * @author Christian Soronellas <csoronellas@emagister.com>
  */
-abstract class Twitter_Bootstrap_Form_Horizontal extends Twitter_Bootstrap_Form
+class Twitter_Bootstrap_Form_Horizontal extends Twitter_Bootstrap_Form
 {
     public function __construct($options = null)
     {
@@ -32,7 +32,7 @@ abstract class Twitter_Bootstrap_Form_Horizontal extends Twitter_Bootstrap_Form
             array('Label', array('class' => 'control-label')),
             array('Wrapper')
         ));
-        
+
         parent::__construct($options);
     }
 }

--- a/Twitter/Bootstrap/Form/Inline.php
+++ b/Twitter/Bootstrap/Form/Inline.php
@@ -17,7 +17,7 @@
  * @subpackage Form
  * @author Christian Soronellas <csoronellas@emagister.com>
  */
-abstract class Twitter_Bootstrap_Form_Inline extends Twitter_Bootstrap_Form
+class Twitter_Bootstrap_Form_Inline extends Twitter_Bootstrap_Form
 {
     public function __construct($options = null)
     {
@@ -29,7 +29,7 @@ abstract class Twitter_Bootstrap_Form_Inline extends Twitter_Bootstrap_Form
             array('Description', array('tag' => 'p', 'class' => 'help-block')),
             array('Addon')
         ));
-        
+
         parent::__construct($options);
     }
 }

--- a/Twitter/Bootstrap/Form/Vertical.php
+++ b/Twitter/Bootstrap/Form/Vertical.php
@@ -16,7 +16,7 @@
  * @subpackage Form
  * @author Christian Soronellas <csoronellas@emagister.com>
  */
-abstract class Twitter_Bootstrap_Form_Vertical extends Twitter_Bootstrap_Form
+class Twitter_Bootstrap_Form_Vertical extends Twitter_Bootstrap_Form
 {
     /**
      * Class constructor override.
@@ -32,7 +32,7 @@ abstract class Twitter_Bootstrap_Form_Vertical extends Twitter_Bootstrap_Form
             array('Description', array('tag' => 'p', 'class' => 'help-block')),
             array('Addon')
         ));
-        
+
         parent::__construct($options);
     }
 }


### PR DESCRIPTION
[Zend_Form array notation](http://framework.zend.com/manual/en/zend.form.advanced.html#zend.form.advanced.arrayNotation) require  repeated elements to be subforms. In this use case is required to instantiate form and add it as subform:

``` php
$subForm = new Twitter_Bootstrap_Form_Horizontal();
$subForm->setDecorators(array(
    'FormElements',
));
$subForm->setIsArray(true);

// ... adding elements to subform

$this->addSubForm($subForm, 'subform_name');
```

Another thing is that it is impossible to create a pure form and configure it using the API.
