### PR TITLE
FieldSize decorator - increased range of allowed sizes

### DIFF
--- a/Twitter/Bootstrap/Form/Decorator/FieldSize.php
+++ b/Twitter/Bootstrap/Form/Decorator/FieldSize.php
@@ -29,7 +29,7 @@ class Twitter_Bootstrap_Form_Decorator_FieldSize extends Zend_Form_Decorator_Abs
         // Only apply this decorator to the Inputs, Selects or Textareas
         if (false !== ($size = $element->getAttrib('dimension'))) {
             $classes = explode(' ', $element->getAttrib('class'));
-            if ((int) $size > 1 && (int) $size < 12) {
+            if ((int) $size > 0) {
                 $classes[] = 'span' . $size;
             }
 


### PR DESCRIPTION
Current limitation do not allow to:
- use "span1" field size
- use custom bootstrap grid that have more than 12 columns
