### PR TITLE
Addon decorator - removed PHP_EOL spacing

### DIFF
--- a/Twitter/Bootstrap/Form/Decorator/Addon.php
+++ b/Twitter/Bootstrap/Form/Decorator/Addon.php
@@ -63,7 +63,7 @@ class Twitter_Bootstrap_Form_Decorator_Addon extends Zend_Form_Decorator_Abstrac
         $span = '<span class="' . $addOnClass . '">' . $addOn . '</span>';
 
         return '<div class="input-' . $placement . '">
-                    ' . (('prepend' == $placement) ? $span . PHP_EOL : '') . $content . (('append' == $placement) ? PHP_EOL . $span : '') . '
+                    ' . (('prepend' == $placement) ? $span : '') . $content . (('append' == $placement) ? $span : '') . '
                 </div>';
     }
 }


### PR DESCRIPTION
This white character causes additional spacing.

Picture below shows addon element before and after fix.
![before and after](http://img714.imageshack.us/img714/7964/twitterbootstrapaddonde.png)
