### PR TITLE
Rearragned form classes to make them more easily extendable

### DIFF
--- a/Twitter/Bootstrap/Form.php
+++ b/Twitter/Bootstrap/Form.php
@@ -21,7 +21,7 @@ abstract class Twitter_Bootstrap_Form extends Zend_Form
     /**
      * Class constants
      */
-    const DISPOSITION_VERTICAL 		= 'vertial';
+    const DISPOSITION_VERTICAL 		= 'vertical';
     const DISPOSITION_HORIZONTAL 	= 'horizontal';
     const DISPOSITION_INLINE     	= 'inline';
     const DISPOSTION_SEARCH      	= 'search';

--- a/Twitter/Bootstrap/Form.php
+++ b/Twitter/Bootstrap/Form.php
@@ -21,9 +21,12 @@ abstract class Twitter_Bootstrap_Form extends Zend_Form
     /**
      * Class constants
      */
-    const DISPOSITION_HORIZONTAL = 'horizontal';
-    const DISPOSITION_INLINE     = 'inline';
-    const DISPOSTION_SEARCH      = 'search';
+    const DISPOSITION_VERTICAL 		= 'vertial';
+    const DISPOSITION_HORIZONTAL 	= 'horizontal';
+    const DISPOSITION_INLINE     	= 'inline';
+    const DISPOSTION_SEARCH      	= 'search';
+
+    protected $_disposition = self::DISPOSITION_VERTICAL;
 
     /**
      * Override the base form constructor.
@@ -60,6 +63,26 @@ abstract class Twitter_Bootstrap_Form extends Zend_Form
             'FormElements',
             'Form'
         ));
+        
+	//set the decorators based on what's set in the child form's $_disposition variable
+	switch($this->_disposition) {
+		case self::DISPOSITION_HORIZONTAL:
+			$this->setDisposition(self::DISPOSITION_HORIZONTAL);
+			$options['bootstrapDecorators'] = Twitter_Bootstrap_Form_Horizontal::$defaultElementDecorators;
+			break;
+		case self::DISPOSITION_INLINE:
+			$this->setDisposition(self::DISPOSITION_INLINE);
+			$options['bootstrapDecorators'] = Twitter_Bootstrap_Form_Inline::$defaultElementDecorators;
+			break;
+		case self::DISPOSTION_SEARCH:
+			$this->setDisposition(self::DISPOSTION_SEARCH);
+			break;
+		case self::DISPOSITION_VERTICAL:
+		default:
+			$this->setDisposition(self::DISPOSITION_VERTICAL);
+			$options['bootstrapDecorators'] = Twitter_Bootstrap_Form_Vertical::$defaultElementDecorators;
+			break;			
+	}
 
         parent::__construct($options);
     }
@@ -81,6 +104,15 @@ abstract class Twitter_Bootstrap_Form extends Zend_Form
         ) {
             $this->_addClassNames('form-' . $disposition);
         }
+    }
+
+    /**
+     * Sets form decorators
+     *
+     * @param array $decorators
+     */
+    public function setBootstrapDecorators($decorators) {
+    	$this->setElementDecorators($decorators);
     }
 
     /**

--- a/Twitter/Bootstrap/Form/Horizontal.php
+++ b/Twitter/Bootstrap/Form/Horizontal.php
@@ -16,23 +16,21 @@
  * @subpackage Form
  * @author Christian Soronellas <csoronellas@emagister.com>
  */
-class Twitter_Bootstrap_Form_Horizontal extends Twitter_Bootstrap_Form
+abstract class Twitter_Bootstrap_Form_Horizontal extends Twitter_Bootstrap_Form
 {
-    public function __construct($options = null)
-    {
-        $this->setDisposition(self::DISPOSITION_HORIZONTAL);
-
-        $this->setElementDecorators(array(
-            array('FieldSize'),
-            array('ViewHelper'),
-            array('Addon'),
-            array('ElementErrors'),
-            array('Description', array('tag' => 'p', 'class' => 'help-block')),
-            array('HtmlTag', array('tag' => 'div', 'class' => 'controls')),
-            array('Label', array('class' => 'control-label')),
-            array('Wrapper')
-        ));
-
-        parent::__construct($options);
-    }
+	
+	public static $defaultElementDecorators = array(
+		array('FieldSize'),
+		array('ViewHelper'),
+		array('Addon'),
+		array('ElementErrors'),
+		array('Description', array('tag' => 'p', 'class' => 'help-block')),
+		array('HtmlTag', array('tag' => 'div', 'class' => 'controls')),
+		array('Label', array('class' => 'control-label')),
+		array('Wrapper')
+	);
+	
+	protected $_disposition = Twitter_Bootstrap_Form::DISPOSITION_HORIZONTAL;
+	
 }
+

--- a/Twitter/Bootstrap/Form/Inline.php
+++ b/Twitter/Bootstrap/Form/Inline.php
@@ -17,19 +17,17 @@
  * @subpackage Form
  * @author Christian Soronellas <csoronellas@emagister.com>
  */
-class Twitter_Bootstrap_Form_Inline extends Twitter_Bootstrap_Form
+abstract class Twitter_Bootstrap_Form_Inline extends Twitter_Bootstrap_Form
 {
-    public function __construct($options = null)
-    {
-        $this->setDisposition(self::DISPOSITION_INLINE);
-
-        $this->setElementDecorators(array(
-            array('FieldSize'),
-            array('ViewHelper'),
-            array('Description', array('tag' => 'p', 'class' => 'help-block')),
-            array('Addon')
-        ));
-
-        parent::__construct($options);
-    }
+	
+	public static $defaultElementDecorators = array(
+		array('FieldSize'),
+		array('ViewHelper'),
+		array('Description', array('tag' => 'p', 'class' => 'help-block')),
+		array('Addon')
+	);
+	
+	protected $_disposition = Twitter_Bootstrap_Form::DISPOSITION_INLINE;
+	
 }
+

--- a/Twitter/Bootstrap/Form/Search.php
+++ b/Twitter/Bootstrap/Form/Search.php
@@ -18,6 +18,8 @@
  */
 final class Twitter_Bootstrap_Form_Search extends Twitter_Bootstrap_Form_Inline
 {
+    protected $_disposition = Twitter_Bootstrap_Form::DISPOSTION_SEARCH;
+
     public function __construct($options = null)
     {
         $this->setDisposition(self::DISPOSTION_SEARCH);

--- a/Twitter/Bootstrap/Form/Subform.php
+++ b/Twitter/Bootstrap/Form/Subform.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * A custom display group definition for Twitter's Bootstrap forms
+ *
+ * @category Forms
+ * @package Twitter_Bootstrap
+ * @subpackage Form
+ * @author Christian Soronellas <csoronellas@emagister.com>
+ */
+
+/**
+ * Displays the fieldsets the Bootstrap's way
+ *
+ * @category Forms
+ * @package Twitter_Bootstrap
+ * @subpackage Form
+ */
+class Twitter_Bootstrap_Form_SubForm extends Zend_Form_SubForm
+{
+	
+    protected $_decorators = array(
+	array(
+		'decorator' => 'FormElements',
+		'options' => array()
+	),
+	array(
+		'decorator' => 'HtmlTag',
+		'options' => array('tag' => 'div', 'class' => 'control-group')
+	),
+	array(
+		'decorator' => 'Fieldset',
+		'options' => array()
+	),
+    );
+	
+    protected $_elementDecorators = array(
+    	'FieldSize',
+    	'ViewHelper',
+    	'Addon',
+        'ElementErrors',
+        array('Description', array('tag' => 'p', 'class' => 'description')),
+        array('HtmlTag',     array('tag' => 'div', 'class' => 'controls')),
+        array('Label',       array('class' => 'control-label')),
+        'Wrapper',
+    );
+	
+    
+    public function __construct($options = null) {
+        $this->getView()->addHelperPath(
+            'Twitter/Bootstrap/View/Helper',
+            'Twitter_Bootstrap_View_Helper'
+        );
+
+        $this->addPrefixPath(
+            'Twitter_Bootstrap_Form_Element',
+            'Twitter/Bootstrap/Form/Element',
+            'element'
+        );
+
+        $this->addElementPrefixPath(
+            'Twitter_Bootstrap_Form_Decorator',
+            'Twitter/Bootstrap/Form/Decorator',
+            'decorator'
+        );
+
+        $this->addDisplayGroupPrefixPath(
+            'Twitter_Bootstrap_Form_Decorator',
+            'Twitter/Bootstrap/Form/Decorator'
+        );
+        
+        parent::__construct($options);
+    }
+
+}
+

--- a/Twitter/Bootstrap/Form/Vertical.php
+++ b/Twitter/Bootstrap/Form/Vertical.php
@@ -16,23 +16,23 @@
  * @subpackage Form
  * @author Christian Soronellas <csoronellas@emagister.com>
  */
-class Twitter_Bootstrap_Form_Vertical extends Twitter_Bootstrap_Form
+abstract class Twitter_Bootstrap_Form_Vertical extends Twitter_Bootstrap_Form
 {
     /**
      * Class constructor override.
      *
      * @param null $options
      */
-    public function __construct($options = null)
-    {
-        $this->setElementDecorators(array(
-            array('FieldSize'),
-            array('ViewHelper'),
-            array('ElementErrors'),
-            array('Description', array('tag' => 'p', 'class' => 'help-block')),
-            array('Addon')
-        ));
+	
+	public static $defaultElementDecorators = array(
+		array('FieldSize'),
+		array('ViewHelper'),
+		array('ElementErrors'),
+		array('Description', array('tag' => 'p', 'class' => 'help-block')),
+		array('Addon')
+	);
+	
+	protected $_disposition = Twitter_Bootstrap_Form::DISPOSITION_VERTICAL;
 
-        parent::__construct($options);
-    }
 }
+


### PR DESCRIPTION
This change should make it easier for anyone that wants to use Twitter_Bootstrap_Form_\* in their existing project, but all of their forms already extend a master form that extends Zend_Form.  

My problem:
In many of my other projects I have a master form that all other forms extend.  This master form extends Zend_Form, and is used for logging and other housekeeping.  I wanted to use all of the vertical, horizontal, etc. bootstrap forms in my project, but the problem is figuring out how to extend them.  If I have all of my base forms extend the twitter forms, then I lose everything in my master form.  I could make my master form extend the Horizontal form, but then I couldn't use Vertical.  I could extend Twitter_Bootstrap_Form directly, but then I have to manually set the decorators on each child form, defeating the purpose of this project entirely.

My fix:
I removed the contructors from Horizontal, Vertical, and Inline, and moved their decorators to a protected array called $defaultElementDecorators.  Then in the Twitter_Bootstrap_Form's constructor I set the decorators based on whatever the extending form's $_disposition is.  So you can still extend any of the bootstrap forms as normal, or you can extend Twitter_Bootstrap_Form directly like so:

``` php
class My_Master_Form extends Twitter_Bootstrap_Form {
    //set all forms to horizontal by default
    protected $_disposition = Twitter_Bootstrap_Form::DISPOSITION_HORIZONTAL;
    ...
}

class My_Page_Form extends My_Master_Form {
    //set this form to inline
    protected $_disposition = Twitter_Bootstrap_Form::DISPOSITION_INLINE;
    ....
}
```
