### PR TITLE
Hotfix/label submit

### DIFF
--- a/Twitter/Bootstrap/Form/Decorator/Label.php
+++ b/Twitter/Bootstrap/Form/Decorator/Label.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Description of Label
+ *
+ * @author David Weinraub <david@papayasoft.com>
+ */
+class Twitter_Bootstrap_Form_Decorator_Label extends Zend_Form_Decorator_Label
+{
+    public function render($content)
+    {
+        $element = $this->getElement();
+        if ($element instanceof Zend_Form_Element_Submit){
+            return $content;
+        } else {
+            return parent::render($content);
+        }
+    }
+}

--- a/Twitter/Bootstrap/Form/Decorator/Label.php
+++ b/Twitter/Bootstrap/Form/Decorator/Label.php
@@ -1,16 +1,34 @@
 <?php
 
 /**
- * Description of Label
+ * Label decorator definition
  *
- * @author David Weinraub <david@papayasoft.com>
+ * @category Forms
+ * @package Twitter_Bootstrap_Form_Decorator
+ * @subpackage Label
+ * @author David Weinraub <david@papyasoft.com>
+ */
+
+/**
+ * Renders the label for an element
+ *
+ * @category Forms
+ * @package Twitter_Bootstrap_Form_Decorator
+ * @subpackage Label
+ * @author David Weinraub <david@papyasoft.com>
  */
 class Twitter_Bootstrap_Form_Decorator_Label extends Zend_Form_Decorator_Label
 {
+    /**
+     * Render the label. Suppress label rendering for submit buttons.
+     * 
+     * @param string $content 
+     * @return string
+     */
     public function render($content)
     {
         $element = $this->getElement();
-        if ($element instanceof Zend_Form_Element_Submit){
+        if ($element instanceof Zend_Form_Element_Submit) {
             return $content;
         } else {
             return parent::render($content);


### PR DESCRIPTION
Addresses Issue #9: Button label when not using display group

https://github.com/Emagister/zend-form-decorators-bootstrap/issues/9

I, too, am seeing labels rendered for submit buttons.

This fix is a quck hack that creates a Label decorator extending Zend_Form_Decorator_Label that simply bails if the element is a submit button; otherwise, it passes along to the parent.
