### PR TITLE
Fix submit button & icon

### DIFF
--- a/Twitter/Bootstrap/Form/Element/Button.php
+++ b/Twitter/Bootstrap/Form/Element/Button.php
@@ -55,7 +55,7 @@ class Twitter_Bootstrap_Form_Element_Button extends Twitter_Bootstrap_Form_Eleme
      */
     private function _renderIcon()
     {
-        return '<i class="' . $this->_icon . '"></i>';
+        return isset($this->_icon) ? '<i class="' . $this->_icon . '"></i>' : '';
     }
 
     /**


### PR DESCRIPTION
Hi,

If no icon is defined for a submit button, label is displayed with a padding left (due to `<i class="icon-"></i>` on the left).

I just update `_renderIcon` to return an empty string is `$this->_icon` is empty.

Thank you for this project ;)
