### PR TITLE
Fixed the issue with Radio and MultiCheckboxes

### DIFF
--- a/Twitter/Bootstrap/Form.php
+++ b/Twitter/Bootstrap/Form.php
@@ -24,6 +24,8 @@ abstract class Twitter_Bootstrap_Form extends Zend_Form
     const DISPOSITION_HORIZONTAL = 'horizontal';
     const DISPOSITION_INLINE     = 'inline';
     const DISPOSITION_SEARCH     = 'search';
+    
+    protected $_prefixesInitialized = false;
 
     /**
      * Override the base form constructor.
@@ -32,36 +34,45 @@ abstract class Twitter_Bootstrap_Form extends Zend_Form
      */
     public function __construct($options = null)
     {
-        $this->getView()->addHelperPath(
-            'Twitter/Bootstrap/View/Helper',
-            'Twitter_Bootstrap_View_Helper'
-        );
-
-        $this->addPrefixPath(
-            'Twitter_Bootstrap_Form_Element',
-            'Twitter/Bootstrap/Form/Element',
-            'element'
-        );
-
-        $this->addElementPrefixPath(
-            'Twitter_Bootstrap_Form_Decorator',
-            'Twitter/Bootstrap/Form/Decorator',
-            'decorator'
-        );
-
-        $this->addDisplayGroupPrefixPath(
-            'Twitter_Bootstrap_Form_Decorator',
-            'Twitter/Bootstrap/Form/Decorator'
-        );
-
-        $this->setDefaultDisplayGroupClass('Twitter_Bootstrap_Form_DisplayGroup');
-
+        $this->_initializePrefixes();
         $this->setDecorators(array(
             'FormElements',
             'Form'
         ));
 
         parent::__construct($options);
+    }
+    
+    protected function _initializePrefixes()
+    {
+        if (!$this->_prefixesInitialized)
+        {
+            $this->getView()->addHelperPath(
+                    'Twitter/Bootstrap/View/Helper',
+                    'Twitter_Bootstrap_View_Helper'
+            );
+            
+            $this->addPrefixPath(
+                    'Twitter_Bootstrap_Form_Element',
+                    'Twitter/Bootstrap/Form/Element',
+                    'element'
+            );
+            
+            $this->addElementPrefixPath(
+                    'Twitter_Bootstrap_Form_Decorator',
+                    'Twitter/Bootstrap/Form/Decorator',
+                    'decorator'
+            );
+            
+            $this->addDisplayGroupPrefixPath(
+                    'Twitter_Bootstrap_Form_Decorator',
+                    'Twitter/Bootstrap/Form/Decorator'
+            );
+            
+            $this->setDefaultDisplayGroupClass('Twitter_Bootstrap_Form_DisplayGroup');
+            
+            $this->_prefixesInitialized = true;
+        }
     }
 
     /**

--- a/Twitter/Bootstrap/Form/Element/File.php
+++ b/Twitter/Bootstrap/Form/Element/File.php
@@ -28,7 +28,10 @@ class Twitter_Bootstrap_Form_Element_File extends Zend_Form_Element_File
         }
 
         if (!$this->_existsFileDecorator()) {
-            $this->addDecorator('File');
+            // Add the file decorator to the beginning
+            $decorators = array_merge(array('File'), $this->getDecorators());
+            $this->setDecorators($decorators);
+            $this->removeDecorator('ViewHelper');
         }
         return $this;
     }

--- a/Twitter/Bootstrap/Form/Element/MultiCheckbox.php
+++ b/Twitter/Bootstrap/Form/Element/MultiCheckbox.php
@@ -10,14 +10,14 @@
  */
 
 /**
- * Twitter's Bootstrap radio buttons
+ * Twitter's Bootstrap multi checkboxes
  *
  * @category Forms
  * @package Twitter_Bootstrap_Form
  * @subpackage Element
  * @author Christian Soronellas <csoronellas@emagister.com>
  */
-class Twitter_Bootstrap_Form_Element_Radio extends Zend_Form_Element_Radio
+class Twitter_Bootstrap_Form_Element_MultiCheckbox extends Zend_Form_Element_MultiCheckbox
 {
     /**
      * The default separator (Changed to be nothing for bootstrap)

--- a/Twitter/Bootstrap/Form/Horizontal.php
+++ b/Twitter/Bootstrap/Form/Horizontal.php
@@ -20,8 +20,8 @@ class Twitter_Bootstrap_Form_Horizontal extends Twitter_Bootstrap_Form
 {
     public function __construct($options = null)
     {
-        parent::__construct($options);
-
+        $this->_initializePrefixes();
+        
         $this->setDisposition(self::DISPOSITION_HORIZONTAL);
 
         $this->setElementDecorators(array(
@@ -34,5 +34,7 @@ class Twitter_Bootstrap_Form_Horizontal extends Twitter_Bootstrap_Form
             array('Label', array('class' => 'control-label')),
             array('Wrapper')
         ));
+        
+        parent::__construct($options);
     }
 }

--- a/Twitter/Bootstrap/Form/Inline.php
+++ b/Twitter/Bootstrap/Form/Inline.php
@@ -21,7 +21,7 @@ class Twitter_Bootstrap_Form_Inline extends Twitter_Bootstrap_Form
 {
     public function __construct($options = null)
     {
-        parent::__construct($options);
+        $this->_initializePrefixes();
         
         $this->setDisposition(self::DISPOSITION_INLINE);
 
@@ -31,5 +31,7 @@ class Twitter_Bootstrap_Form_Inline extends Twitter_Bootstrap_Form
             array('Description', array('tag' => 'p', 'class' => 'help-block')),
             array('Addon')
         ));
+        
+        parent::__construct($options);
     }
 }

--- a/Twitter/Bootstrap/Form/Search.php
+++ b/Twitter/Bootstrap/Form/Search.php
@@ -20,7 +20,7 @@ final class Twitter_Bootstrap_Form_Search extends Twitter_Bootstrap_Form_Inline
 {
     public function __construct($options = null)
     {
-        parent::__construct($options);
+        $this->_initializePrefixes();
         
         $this->setDisposition(self::DISPOSITION_SEARCH);
 
@@ -51,5 +51,7 @@ final class Twitter_Bootstrap_Form_Search extends Twitter_Bootstrap_Form_Inline
                 'label' => $buttonLabel
             ));
         }
+        
+        parent::__construct($options);
     }
 }

--- a/Twitter/Bootstrap/Form/Vertical.php
+++ b/Twitter/Bootstrap/Form/Vertical.php
@@ -25,8 +25,8 @@ class Twitter_Bootstrap_Form_Vertical extends Twitter_Bootstrap_Form
      */
     public function __construct($options = null)
     {
-        parent::__construct($options);
-
+        $this->_initializePrefixes();
+        
         $this->setElementDecorators(array(
             array('FieldSize'),
             array('ViewHelper'),
@@ -34,5 +34,7 @@ class Twitter_Bootstrap_Form_Vertical extends Twitter_Bootstrap_Form
             array('Description', array('tag' => 'p', 'class' => 'help-block')),
             array('Addon')
         ));
+        
+        parent::__construct($options);
     }
 }


### PR DESCRIPTION
fixes #39 - Radio and MultiCheckboxes now get rendered with no breakline between each element.

Updated the git ignore to avoid commiting project files.

My earlier fix for horizontal forms had to be changed to initialize prefixes but not call the parent constructor until we had set the default decorators. File elements were no longer rendering due to this.

7e64dfc005c611f4e8f3f1595b299450aeca3ebb fixes #27
