### PR TITLE
add include-path for ZF 1.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,9 @@
       "php":">=5.2.4"
     },
     "autoload":{
-    "psr-0":{
-        "Twitter_":"Twitter/"
-    }
-}
+        "psr-0":{
+            "Twitter_":"Twitter/"
+        }
+    },
+	"include-path": [""]
 }


### PR DESCRIPTION
Hi,

sorry for the mess. I needed to add the include-path tag so composer will add the Twitter Library into it's vendor/composer/include_path.php. 

This is needed for Zend Autoloader to work in ZF 1.11. (At least in my projects)

thx, dready
