### PR TITLE
Fix Twitter_Bootstrap_Form if getView is NULL

### DIFF
--- a/Twitter/Bootstrap/Form.php
+++ b/Twitter/Bootstrap/Form.php
@@ -47,13 +47,14 @@ abstract class Twitter_Bootstrap_Form extends Zend_Form
     {
         if (!$this->_prefixesInitialized)
         {
-            if (!is_null($this->getView)) {
+            if (null !== $this->getView())
+            {
                 $this->getView()->addHelperPath(
                         'Twitter/Bootstrap/View/Helper',
                         'Twitter_Bootstrap_View_Helper'
                 );
             }
-            
+
             $this->addPrefixPath(
                     'Twitter_Bootstrap_Form_Element',
                     'Twitter/Bootstrap/Form/Element',

--- a/Twitter/Bootstrap/Form.php
+++ b/Twitter/Bootstrap/Form.php
@@ -47,10 +47,12 @@ abstract class Twitter_Bootstrap_Form extends Zend_Form
     {
         if (!$this->_prefixesInitialized)
         {
-            $this->getView()->addHelperPath(
-                    'Twitter/Bootstrap/View/Helper',
-                    'Twitter_Bootstrap_View_Helper'
-            );
+            if (!is_null($this->getView)) {
+                $this->getView()->addHelperPath(
+                        'Twitter/Bootstrap/View/Helper',
+                        'Twitter_Bootstrap_View_Helper'
+                );
+            }
             
             $this->addPrefixPath(
                     'Twitter_Bootstrap_Form_Element',


### PR DESCRIPTION
hi,

in Twitter_Bootstrap_Form::_initializePrefixes adds an HelperPath to the View. Unfortunately if you are using Unittests on the Form there is no View. Therefore i added an is_null check.

best regards, dready
