### PR TITLE
Fix Composer autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "autoload":{
     "psr-0":{
-        "Twitter_":"Twitter/"
+        "Twitter_":"/"
     }
 }
 }


### PR DESCRIPTION
The value for psr-0 key must be the directory where the vendor namespace exists
