### PR TITLE
issue #55: try to enable defaults for all elements without overriding user settings

### DIFF
--- a/Twitter/Bootstrap/Form/Horizontal.php
+++ b/Twitter/Bootstrap/Form/Horizontal.php
@@ -24,17 +24,36 @@ class Twitter_Bootstrap_Form_Horizontal extends Twitter_Bootstrap_Form
         
         $this->setDisposition(self::DISPOSITION_HORIZONTAL);
 
-        $this->setElementDecorators(array(
-            array('FieldSize'),
-            array('ViewHelper'),
-            array('Addon'),
-            array('ElementErrors'),
-            array('Description', array('tag' => 'p', 'class' => 'help-block')),
-            array('HtmlTag', array('tag' => 'div', 'class' => 'controls')),
-            array('Label', array('class' => 'control-label')),
-            array('Wrapper')
-        ));
-        
         parent::__construct($options);
+
     }
+
+    /**
+     * Load the default decorators
+     *
+     * @return Zend_Form
+     */
+    public function loadDefaultDecorators()
+    {
+        $elementObjs = $this->getElements();
+        /** @var $element Zend_Form_Element */
+        foreach ($elementObjs as $element) {
+            if ($element->loadDefaultDecoratorsIsDisabled()) {
+                continue;
+            }
+            $element->addDecorators(array(
+                array('FieldSize'),
+                array('ViewHelper'),
+                array('Addon'),
+                array('ElementErrors'),
+                array('Description', array('tag' => 'p', 'class' => 'help-block')),
+                array('HtmlTag', array('tag' => 'div', 'class' => 'controls')),
+                array('Label', array('class' => 'control-label')),
+                array('Wrapper')
+            ));
+        }
+        
+        return parent::loadDefaultDecorators();
+    }
+
 }

--- a/Twitter/Bootstrap/Form/Horizontal.php
+++ b/Twitter/Bootstrap/Form/Horizontal.php
@@ -20,22 +20,40 @@ class Twitter_Bootstrap_Form_Horizontal extends Twitter_Bootstrap_Form
 {
     public function __construct($options = null)
     {
-        parent::__construct($options);
-        
         $this->_initializePrefixes();
         
         $this->setDisposition(self::DISPOSITION_HORIZONTAL);
 
-        $this->setElementDecorators(array(
-            array('FieldSize'),
-            array('ViewHelper'),
-            array('Addon'),
-            array('ElementErrors'),
-            array('Description', array('tag' => 'p', 'class' => 'help-block')),
-            array('HtmlTag', array('tag' => 'div', 'class' => 'controls')),
-            array('Label', array('class' => 'control-label')),
-            array('Wrapper')
-        ));
+        parent::__construct($options);
 
     }
+
+    /**
+     * Load the default decorators
+     *
+     * @return Zend_Form
+     */
+    public function loadDefaultDecorators()
+    {
+        $elementObjs = $this->getElements();
+        /** @var $element Zend_Form_Element */
+        foreach ($elementObjs as $element) {
+            if ($element->loadDefaultDecoratorsIsDisabled()) {
+                continue;
+            }
+            $element->addDecorators(array(
+                array('FieldSize'),
+                array('ViewHelper'),
+                array('Addon'),
+                array('ElementErrors'),
+                array('Description', array('tag' => 'p', 'class' => 'help-block')),
+                array('HtmlTag', array('tag' => 'div', 'class' => 'controls')),
+                array('Label', array('class' => 'control-label')),
+                array('Wrapper')
+            ));
+        }
+        
+        return parent::loadDefaultDecorators();
+    }
+
 }

--- a/Twitter/Bootstrap/Form/Horizontal.php
+++ b/Twitter/Bootstrap/Form/Horizontal.php
@@ -41,6 +41,7 @@ class Twitter_Bootstrap_Form_Horizontal extends Twitter_Bootstrap_Form
             if ($element->loadDefaultDecoratorsIsDisabled()) {
                 continue;
             }
+
             $element->addDecorators(array(
                 array('FieldSize'),
                 array('ViewHelper'),
@@ -51,9 +52,30 @@ class Twitter_Bootstrap_Form_Horizontal extends Twitter_Bootstrap_Form
                 array('Label', array('class' => 'control-label')),
                 array('Wrapper')
             ));
+
+            $this->_sortFieldSizeFirst($element);
         }
         
         return parent::loadDefaultDecorators();
     }
 
+    /**
+     * We need to sort the fieldsize decorator first or it will be ignored if the viewhelper has already been called
+     *
+     * @param $element
+     */
+    protected function _sortFieldSizeFirst($element)
+    {
+        $decorators = $element->getDecorators();
+        $i= 0;
+        foreach ($decorators as $decorator) {
+            if ($decorator instanceof Twitter_Bootstrap_Form_Decorator_FieldSize) {
+                $fieldsize = array_slice($decorators, $i);
+                array_unshift($decorators, $fieldsize);
+                break;
+            }
+            $i++;
+        }
+        $element->setDecorators(array_values($decorators));
+    }
 }

--- a/Twitter/Bootstrap/Form/Horizontal.php
+++ b/Twitter/Bootstrap/Form/Horizontal.php
@@ -20,6 +20,8 @@ class Twitter_Bootstrap_Form_Horizontal extends Twitter_Bootstrap_Form
 {
     public function __construct($options = null)
     {
+        parent::__construct($options);
+        
         $this->_initializePrefixes();
         
         $this->setDisposition(self::DISPOSITION_HORIZONTAL);
@@ -34,7 +36,6 @@ class Twitter_Bootstrap_Form_Horizontal extends Twitter_Bootstrap_Form
             array('Label', array('class' => 'control-label')),
             array('Wrapper')
         ));
-        
-        parent::__construct($options);
+
     }
 }


### PR DESCRIPTION
Hi!

As described in issue #55 new created elements don't get the defaults since setElementsDecorators has not waited for the init method. 

Therefore i tried to enable that behaviour without breaking the file element (the reason the parent constructor is called last).

In my tests it looks alright but i am unsure if i missed something.

If Defaults are disabled the user is able to use their own decorators.

hopefully this does the trick.

bests
