### PR TITLE
remove all decorators and just add the ViewHelper for hidden elements

### DIFF
--- a/Twitter/Bootstrap/Form.php
+++ b/Twitter/Bootstrap/Form.php
@@ -97,6 +97,11 @@ abstract class Twitter_Bootstrap_Form extends Zend_Form
                 $options['decorators'] = $this->_elementDecorators;
             }
         }
+
+	    // no decorators for hidden elements
+	    if ($type == 'hidden') {
+		    $options["decorators"] = array('ViewHelper');
+	    }
         
         return parent::createElement($type, $name, $options);
     }


### PR DESCRIPTION
as described in issue 63 hidden fields get default decorators even if they just should be hidden
