### PR TITLE
Fix Html Errors not escaping in Form Errors

### DIFF
--- a/Twitter/Bootstrap/Form/Decorator/ElementErrors.php
+++ b/Twitter/Bootstrap/Form/Decorator/ElementErrors.php
@@ -28,8 +28,22 @@ class Twitter_Bootstrap_Form_Decorator_ElementErrors extends Zend_Form_Decorator
             return $content;
         }
 
-        $errors = implode('. ', $this->getElement()->getMessages());
+	    $options = $this->getOptions();
+	    $escape = true;
+	    if (isset($options['escape'])) {
+		    $escape = (bool) $options['escape'];
+	    }
 
-        return $content . '<span class="help-inline">' . $errors . '</span>';
+	    $errors = $this->getElement()->getMessages();
+	    if ($escape) {
+		    $view = $this->getElement()->getView();
+		    foreach ($errors as $key => $message) {
+				$errors[$key] = $view->escape($message);
+		    }
+	    }
+
+        $errormessage = implode('. ', $errors);
+
+        return $content . '<span class="help-inline">' . $errormessage . '</span>';
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,9 @@
     "autoload":{
         "psr-0":{
             "Twitter_":""
-        },
+        }
     },
     "include-path": [
        ""
     ]
-}
 }


### PR DESCRIPTION
At the Moment all Errors are shown as is, without any escaping which may leave into a borked Message if the Value which was entered by the User has not at least been sanitized through htmlentities.

For exampe use 'foo<bar' will only show 'foo'.

Zend uses the View Helper FormErrors which looks if the option escape is set and uses the view->escape method for escaping the message.

This was merged into the ElementErrors Decorator, closing this hole.
