### PR TITLE
Updated Twitter_Bootstrap_Form::_removeClassNames method

### DIFF
--- a/Twitter/Bootstrap/Form.php
+++ b/Twitter/Bootstrap/Form.php
@@ -133,7 +133,7 @@ abstract class Twitter_Bootstrap_Form extends Zend_Form
             $classes[] = $className;
         }
 
-        $this->setAttrib('class', implode(' ', $classes));
+        $this->setAttrib('class', implode(' ', array_unique($classes)));
     }
 
     /**
@@ -143,13 +143,7 @@ abstract class Twitter_Bootstrap_Form extends Zend_Form
      */
     protected function _removeClassNames($classNames)
     {
-        $classes = $this->getAttrib('class');
-
-        foreach ((array) $classNames as $className) {
-            if (false !== strpos($classes, $className)) {
-                str_replace($className . ' ', '', $classes);
-            }
-        }
+        $this->setAttrib('class', implode(' ', array_diff($this->_getClassNames(), (array) $classNames)));
     }
 
     /**


### PR DESCRIPTION
The _removeClassNames method was not saving back to the attributes after removing the class(es). 

Also updated the _addClassNames to not save duplicate class names.
