### PR TITLE
Errors and Description don't show when 'prepend' option set on Vertical form

### DIFF
--- a/Twitter/Bootstrap/Form/Vertical.php
+++ b/Twitter/Bootstrap/Form/Vertical.php
@@ -30,10 +30,11 @@ class Twitter_Bootstrap_Form_Vertical extends Twitter_Bootstrap_Form
         $this->setElementDecorators(array(
             array('FieldSize'),
             array('ViewHelper'),
+            array('Addon'),
             array('ElementErrors'),
             array('Description', array('tag' => 'p', 'class' => 'help-block')),
-            array('Addon'),
             array('Label', array('class' => 'control-label')),
+            array('Wrapper')
         ));
         
         parent::__construct($options);


### PR DESCRIPTION
When you have a form that extends Twitter_Bootstrap_Form_Vertical that adds a "prepend" option, the form errors and description text disappears.  IE:

```
class Twitter_Form_Request extends Twitter_Bootstrap_Form_Vertical
{

    public function init()
    {

        $this->addElement('text', 'handle', array(
            'label' => 'Twitter Account Handle:',
            'description' => 'This is the handle for your account',
            'prepend' => '@',
            'required' => true,
        ));       
    }
}

```

This results in the following upon submitting the form:

![Screen Shot 2013-04-02 at 3 28 20 PM](https://f.cloud.github.com/assets/409778/330379/8ec5df94-9bcb-11e2-85a1-11798a9f72d2.png)

The expected result would be:

![Screen Shot 2013-04-02 at 3 29 47 PM](https://f.cloud.github.com/assets/409778/330385/b791fd72-9bcb-11e2-85cf-e2c199807b24.png)

This happens because of bootstrap's CSS where additional elements inside the "input-prepend" element are not shown in the way they are intended.  The code is echoed in the HTML, but it's inside the "input-prepend" div.  

The attached code moves the error and description elements outside of that div and into a wrapper div, allowing for the proper view to take place.  It also now correctly assigns the "error" class to the "control-group" wrapper.

Thanks for the awesome library!
