### PR TITLE
parent __construct must be always the last

### DIFF
--- a/Twitter/Bootstrap/Form.php
+++ b/Twitter/Bootstrap/Form.php
@@ -36,12 +36,12 @@ abstract class Twitter_Bootstrap_Form extends Zend_Form
     {
         $this->_initializePrefixes();
 
-        parent::__construct($options);
-
         $this->setDecorators(array(
             'FormElements',
             'Form'
         ));
+
+        parent::__construct($options);
     }
 
     protected function _initializePrefixes()


### PR DESCRIPTION
__construct must be the last method because is the responsible for to call init()

Undo part of the changes in #89
