### PR TITLE
Made private method protected to allow extension

### DIFF
--- a/Twitter/Bootstrap/Form/Element/File.php
+++ b/Twitter/Bootstrap/Form/Element/File.php
@@ -40,7 +40,7 @@ class Twitter_Bootstrap_Form_Element_File extends Zend_Form_Element_File
      * Checks if a file decorator has been added to the decorators
      * stack
      */
-    private function _existsFileDecorator()
+    protected function _existsFileDecorator()
     {
         foreach ($this->getDecorators() as $decorator) {
             if ($decorator instanceof Zend_Form_Decorator_Marker_File_Interface) {


### PR DESCRIPTION
This class is closed to extension; due to the private method, overriding the loadDefaultDecorators to load a new set of decorators became harder than needed. I see no clear advantage of having _existsFileDecorator marked as private, so suggesting to make it public instead.
