### PR TITLE
Avoid the PDO Exception when we try to serialize the form with a db row

### DIFF
--- a/Twitter/Bootstrap/Form.php
+++ b/Twitter/Bootstrap/Form.php
@@ -190,4 +190,9 @@ abstract class Twitter_Bootstrap_Form extends Zend_Form
          */
         return parent::render($view);
     }
+
+    public function __sleep()
+    {
+        return array();
+    }
 }


### PR DESCRIPTION
Avoid the PDO Exception when we try to serialize the form hydrated with a db row.

PHP 5.4
