### PR TITLE
Remove stray surrounding whitespace from css class name(s).

### DIFF
--- a/Twitter/Bootstrap/Form/Decorator/Wrapper.php
+++ b/Twitter/Bootstrap/Form/Decorator/Wrapper.php
@@ -35,7 +35,7 @@ class Twitter_Bootstrap_Form_Decorator_Wrapper extends Zend_Form_Decorator_HtmlT
         $hasErrors = $this->getElement()->hasErrors() ? 'has-error' : '';
         $class .= " form-group $hasErrors";
 
-        $this->setOption('class', $class);
+        $this->setOption('class', trim($class));
 
         return parent::render($content);
     }

--- a/Twitter/Bootstrap/Form/Element/Reset.php
+++ b/Twitter/Bootstrap/Form/Element/Reset.php
@@ -26,7 +26,7 @@ class Twitter_Bootstrap_Form_Element_Reset extends Zend_Form_Element_Reset
     const BUTTON_INVERSE = 'inverse';
     const BUTTON_LINK = 'link';
 
-    protected $buttons = array(
+    protected $_buttons = array(
         self::BUTTON_DANGER,
         self::BUTTON_INFO,
         self::BUTTON_PRIMARY,
@@ -52,7 +52,7 @@ class Twitter_Bootstrap_Form_Element_Reset extends Zend_Form_Element_Reset
         $classes = explode(' ', $options['class']);
         $classes[] = 'btn btn-default';
 
-        if (isset($options['buttonType']) && in_array( $options['buttonType'], $this->buttons )) {
+        if (isset($options['buttonType']) && in_array( $options['buttonType'], $this->_buttons )) {
             $classes[] = 'btn-' . $options['buttonType'];
             unset($options['buttonType']);
         }

--- a/Twitter/Bootstrap/Form/Element/Submit.php
+++ b/Twitter/Bootstrap/Form/Element/Submit.php
@@ -26,7 +26,7 @@ class Twitter_Bootstrap_Form_Element_Submit extends Zend_Form_Element_Submit
     const BUTTON_INVERSE = 'inverse';
     const BUTTON_LINK = 'link';
 
-    protected $buttons = array(
+    protected $_buttons = array(
         self::BUTTON_DANGER,
         self::BUTTON_INFO,
         self::BUTTON_PRIMARY,
@@ -52,7 +52,7 @@ class Twitter_Bootstrap_Form_Element_Submit extends Zend_Form_Element_Submit
         $classes = explode(' ', $options['class']);
         $classes[] = 'btn btn-default';
 
-        if (isset($options['buttonType']) && in_array( $options['buttonType'], $this->buttons )) {
+        if (isset($options['buttonType']) && in_array( $options['buttonType'], $this->_buttons )) {
             $classes[] = 'btn-' . $options['buttonType'];
             unset($options['buttonType']);
         }


### PR DESCRIPTION
Elements are often wrapped in a div with `class=" form-group "`. This simply trims the extra whitespace around the class names.
