### PR TITLE
Remove 'buttons' HTML attribute from submit and reset buttons

### DIFF
--- a/Twitter/Bootstrap/Form/Element/Reset.php
+++ b/Twitter/Bootstrap/Form/Element/Reset.php
@@ -26,7 +26,7 @@ class Twitter_Bootstrap_Form_Element_Reset extends Zend_Form_Element_Reset
     const BUTTON_INVERSE = 'inverse';
     const BUTTON_LINK = 'link';
 
-    protected $buttons = array(
+    protected $_buttons = array(
         self::BUTTON_DANGER,
         self::BUTTON_INFO,
         self::BUTTON_PRIMARY,
@@ -52,7 +52,7 @@ class Twitter_Bootstrap_Form_Element_Reset extends Zend_Form_Element_Reset
         $classes = explode(' ', $options['class']);
         $classes[] = 'btn btn-default';
 
-        if (isset($options['buttonType']) && in_array( $options['buttonType'], $this->buttons )) {
+        if (isset($options['buttonType']) && in_array( $options['buttonType'], $this->_buttons )) {
             $classes[] = 'btn-' . $options['buttonType'];
             unset($options['buttonType']);
         }

--- a/Twitter/Bootstrap/Form/Element/Submit.php
+++ b/Twitter/Bootstrap/Form/Element/Submit.php
@@ -26,7 +26,7 @@ class Twitter_Bootstrap_Form_Element_Submit extends Zend_Form_Element_Submit
     const BUTTON_INVERSE = 'inverse';
     const BUTTON_LINK = 'link';
 
-    protected $buttons = array(
+    protected $_buttons = array(
         self::BUTTON_DANGER,
         self::BUTTON_INFO,
         self::BUTTON_PRIMARY,
@@ -52,7 +52,7 @@ class Twitter_Bootstrap_Form_Element_Submit extends Zend_Form_Element_Submit
         $classes = explode(' ', $options['class']);
         $classes[] = 'btn btn-default';
 
-        if (isset($options['buttonType']) && in_array( $options['buttonType'], $this->buttons )) {
+        if (isset($options['buttonType']) && in_array( $options['buttonType'], $this->_buttons )) {
             $classes[] = 'btn-' . $options['buttonType'];
             unset($options['buttonType']);
         }


### PR DESCRIPTION
The 'buttons' class variable was causing a 'buttons' HTML attribute to
be generated (buttons="danger info primary success warning inverse link").

The leading underscore is parsed by Zend_Form_Element::getAttribs in order
to remove it from the HTML attributes list.
