### PR TITLE
Remove stray surrounding whitespace from css class name(s).

### DIFF
--- a/Twitter/Bootstrap/Form/Decorator/Wrapper.php
+++ b/Twitter/Bootstrap/Form/Decorator/Wrapper.php
@@ -35,7 +35,7 @@ class Twitter_Bootstrap_Form_Decorator_Wrapper extends Zend_Form_Decorator_HtmlT
         $hasErrors = $this->getElement()->hasErrors() ? 'has-error' : '';
         $class .= " form-group $hasErrors";
 
-        $this->setOption('class', $class);
+        $this->setOption('class', trim($class));
 
         return parent::render($content);
     }


### PR DESCRIPTION
Elements are often wrapped in a div with `class=" form-group "`. This simply trims the extra whitespace around the class names.
